### PR TITLE
prevent safari on mac getting stuck

### DIFF
--- a/src/player.html
+++ b/src/player.html
@@ -50,6 +50,9 @@
                 var hls = new Hls();
                 hls.loadSource(hlsPlaylist);
                 hls.attachMedia(video);
+                hls.on(Hls.Events.MANIFEST_PARSED,function() {
+                  video.play();
+                });
               });
           }
           //DASH Support?

--- a/src/player.html
+++ b/src/player.html
@@ -10,7 +10,7 @@
   </head>
   <body>
     <!-- You can refer to the PLYR documentation for options on this players tag -->
-    <video preload="none" id="player" autoplay controls crossorigin></video>
+    <video preload="none" id="player" controls crossorigin></video>
     <script type="text/javascript">
         // Dynamically load Javascript with Callback (https://gist.github.com/hagenburger/500716)
         var JavaScript = {


### PR DESCRIPTION
safari on mac seems to have an issue with starting playback, so the autoplay helps to workaround this issue until a real solution can be found, the autoplay for dash can be left disabled as in pull request #11